### PR TITLE
Add a `withTriggerStyles` function to the project

### DIFF
--- a/src/Dropdown.elm
+++ b/src/Dropdown.elm
@@ -24,27 +24,41 @@ module Dropdown
         , withSelectedClass
         , withSelectedStyles
         , withTriggerClass
+        , withTriggerStyles
         )
 
 {-| Dropdown component
 
+
 # Types
+
 @docs Config, State, Msg
 
+
 # Configuration
+
 @docs newConfig, withClear, withPrompt
 
+
 # Styling
-@docs withArrowClass, withArrowStyles, withArrowSvgClass, withClearClass, withClearStyles, withClearSvgClass, withItemClass, withItemStyles, withMenuClass, withMenuStyles, withPromptClass, withPromptStyles, withSelectedClass, withSelectedStyles, withTriggerClass
+
+@docs withArrowClass, withArrowStyles, withArrowSvgClass, withClearClass, withClearStyles, withClearSvgClass, withItemClass, withItemStyles, withMenuClass, withMenuStyles, withPromptClass, withPromptStyles, withSelectedClass, withSelectedStyles, withTriggerClass, withTriggerStyles
+
 
 # State
+
 @docs newState
 
+
 # view
+
 @docs view
 
+
 # Update
+
 @docs update
+
 -}
 
 import Dropdown.Messages as Messages
@@ -54,45 +68,42 @@ import Dropdown.View as View
 import Html exposing (Html)
 
 
-{-|
-Opaque type that holds the configuration
+{-| Opaque type that holds the configuration
 -}
 type Config msg item
     = PrivateConfig (Models.Config msg item)
 
 
-{-|
-Opaque type that holds the current state
+{-| Opaque type that holds the current state
 -}
 type State
     = PrivateState Models.State
 
 
-{-|
-Opaque type for internal library messages
+{-| Opaque type for internal library messages
 -}
 type Msg item
     = PrivateMsg (Messages.Msg item)
 
 
-{-|
-Create a new configuration. This takes:
+{-| Create a new configuration. This takes:
 
-- A message to trigger when an item is selected
-- A function to get a label to display from an item
+  - A message to trigger when an item is selected
 
+  - A function to get a label to display from an item
 
     Dropdown.newConfig OnSelect .label
+
 -}
 newConfig : (Maybe item -> msg) -> (item -> String) -> Config msg item
 newConfig onSelectMessage toLabel =
     PrivateConfig (Models.newConfig onSelectMessage toLabel)
 
 
-{-|
-Add classes to the arrow wrapper
+{-| Add classes to the arrow wrapper
 
     Dropdown.withArrowClass "arrow" config
+
 -}
 withArrowClass : String -> Config msg item -> Config msg item
 withArrowClass classes config =
@@ -103,10 +114,10 @@ withArrowClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add styles to the arrow wrapper
+{-| Add styles to the arrow wrapper
 
     Dropdown.withArrowStyles [("color", "red")] config
+
 -}
 withArrowStyles : List ( String, String ) -> Config msg item -> Config msg item
 withArrowStyles styles config =
@@ -117,10 +128,10 @@ withArrowStyles styles config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the arrow svg icon
+{-| Add classes to the arrow svg icon
 
     Dropdown.withArrowSvgClass "arrow" config
+
 -}
 withArrowSvgClass : String -> Config msg item -> Config msg item
 withArrowSvgClass classes config =
@@ -131,10 +142,10 @@ withArrowSvgClass classes config =
         fmapConfig fn config
 
 
-{-|
-Show or hide the clear (x) button, default is true
+{-| Show or hide the clear (x) button, default is true
 
     Dropdown.withClear False config
+
 -}
 withClear : Bool -> Config msg item -> Config msg item
 withClear bool config =
@@ -145,10 +156,10 @@ withClear bool config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the clear button wrapper
+{-| Add classes to the clear button wrapper
 
     Dropdown.withClearClass "clear" config
+
 -}
 withClearClass : String -> Config msg item -> Config msg item
 withClearClass classes config =
@@ -159,10 +170,10 @@ withClearClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add styles to the clear button wrapper
+{-| Add styles to the clear button wrapper
 
     Dropdown.withClearStyles [("color", "red")] config
+
 -}
 withClearStyles : List ( String, String ) -> Config msg item -> Config msg item
 withClearStyles styles config =
@@ -173,10 +184,10 @@ withClearStyles styles config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the clear icon
+{-| Add classes to the clear icon
 
     Dropdown.withClearSvgClass "clear" config
+
 -}
 withClearSvgClass : String -> Config msg item -> Config msg item
 withClearSvgClass classes config =
@@ -187,10 +198,10 @@ withClearSvgClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the items in the list
+{-| Add classes to the items in the list
 
     Dropdown.withItemClass "bg-white" config
+
 -}
 withItemClass : String -> Config msg item -> Config msg item
 withItemClass classes config =
@@ -201,10 +212,10 @@ withItemClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add styles to the items in the list
+{-| Add styles to the items in the list
 
     Dropdown.withInputStyles [("color", "red")] config
+
 -}
 withItemStyles : List ( String, String ) -> Config msg item -> Config msg item
 withItemStyles styles config =
@@ -215,10 +226,10 @@ withItemStyles styles config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the menu (list of items)
+{-| Add classes to the menu (list of items)
 
     Dropdown.withMenuClass "bg-white" config
+
 -}
 withMenuClass : String -> Config msg item -> Config msg item
 withMenuClass classes config =
@@ -229,10 +240,10 @@ withMenuClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add styles to menu
+{-| Add styles to menu
 
     Dropdown.withMenuStyles [("color", "red")] config
+
 -}
 withMenuStyles : List ( String, String ) -> Config msg item -> Config msg item
 withMenuStyles styles config =
@@ -243,10 +254,10 @@ withMenuStyles styles config =
         fmapConfig fn config
 
 
-{-|
-Add classes to the prompt text (When no item is selected)
+{-| Add classes to the prompt text (When no item is selected)
 
     Dropdown.withPromptClass "prompt" config
+
 -}
 withPromptClass : String -> Config msg item -> Config msg item
 withPromptClass classes config =
@@ -257,10 +268,10 @@ withPromptClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add a prompt text to be displayed when no element is selected
+{-| Add a prompt text to be displayed when no element is selected
 
     Dropdown.withPrompt "Select a movie" config
+
 -}
 withPrompt : String -> Config msg item -> Config msg item
 withPrompt prompt config =
@@ -271,10 +282,10 @@ withPrompt prompt config =
         fmapConfig fn config
 
 
-{-|
-Add styles to prompt text
+{-| Add styles to prompt text
 
     Dropdown.withPromptStyles [("color", "red")] config
+
 -}
 withPromptStyles : List ( String, String ) -> Config msg item -> Config msg item
 withPromptStyles styles config =
@@ -285,10 +296,10 @@ withPromptStyles styles config =
         fmapConfig fn config
 
 
-{-|
-Add classes to currently selected item in the menu
+{-| Add classes to currently selected item in the menu
 
     Dropdown.withSelectedClass "bg-white" config
+
 -}
 withSelectedClass : String -> Config msg item -> Config msg item
 withSelectedClass classes config =
@@ -299,10 +310,10 @@ withSelectedClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add classes to trigger element
+{-| Add classes to trigger element
 
     Dropdown.withTriggerClass "bg-white" config
+
 -}
 withTriggerClass : String -> Config msg item -> Config msg item
 withTriggerClass classes config =
@@ -313,10 +324,24 @@ withTriggerClass classes config =
         fmapConfig fn config
 
 
-{-|
-Add styles to currently selected item in the menu
+{-| Add styles to trigger element
+
+    Dropdown.withTriggerStyles [("width", "100px")] config
+
+-}
+withTriggerStyles : List ( String, String ) -> Config msg item -> Config msg item
+withTriggerStyles styles config =
+    let
+        fn c =
+            { c | triggerStyles = styles }
+    in
+        fmapConfig fn config
+
+
+{-| Add styles to currently selected item in the menu
 
     Dropdown.withSelectedStyles [("color", "red")] config
+
 -}
 withSelectedStyles : List ( String, String ) -> Config msg item -> Config msg item
 withSelectedStyles styles config =
@@ -327,8 +352,7 @@ withSelectedStyles styles config =
         fmapConfig fn config
 
 
-{-|
-@priv
+{-| @priv
 -}
 fmapConfig : (Models.Config msg item -> Models.Config msg item) -> Config msg item -> Config msg item
 fmapConfig fn config =
@@ -339,23 +363,23 @@ fmapConfig fn config =
         PrivateConfig (fn config_)
 
 
-{-|
-Create a new state. You must pass a unique identifier for each select component.
+{-| Create a new state. You must pass a unique identifier for each select component.
 
     {
         ...
         dropdownState = Dropdown.newState "dropdown1"
     }
+
 -}
 newState : String -> State
 newState id =
     PrivateState (Models.newState id)
 
 
-{-|
-Render the view
+{-| Render the view
 
     Html.map DropdownMsg (Dropdown.view dropdownConfig model.dropdownState model.items selectedItem)
+
 -}
 view : Config msg item -> State -> List item -> Maybe item -> Html (Msg item)
 view config model items selected =
@@ -369,8 +393,7 @@ view config model items selected =
         Html.map PrivateMsg (View.view config_ model_ items selected)
 
 
-{-|
-Update the component state
+{-| Update the component state
 
     DropdownMsg subMsg ->
         let
@@ -378,6 +401,7 @@ Update the component state
                 Dropdown.update dropdownConfig subMsg model.dropdownState
         in
             ( { model | dropdownState = updated }, cmd )
+
 -}
 update : Config msg item -> Msg item -> State -> ( State, Cmd msg )
 update config msg model =
@@ -398,24 +422,21 @@ update config msg model =
             ( PrivateState mdl, cmd )
 
 
-{-|
-@priv
+{-| @priv
 -}
 unwrapConfig : Config msg item -> Models.Config msg item
 unwrapConfig (PrivateConfig config) =
     config
 
 
-{-|
-@priv
+{-| @priv
 -}
 unwrapMsg : Msg item -> Messages.Msg item
 unwrapMsg (PrivateMsg msg) =
     msg
 
 
-{-|
-@priv
+{-| @priv
 -}
 unwrapState : State -> Models.State
 unwrapState (PrivateState state) =

--- a/src/Dropdown/Models.elm
+++ b/src/Dropdown/Models.elm
@@ -25,6 +25,7 @@ type alias Config msg item =
     , selectedStyles : List Style
     , toLabel : item -> String
     , triggerClass : String
+    , triggerStyles : List Style
     }
 
 
@@ -46,6 +47,7 @@ newConfig onSelect toLabel =
     , promptClass = ""
     , promptStyles = []
     , triggerClass = ""
+    , triggerStyles = []
     , selectedClass = ""
     , selectedStyles = []
     , toLabel = toLabel

--- a/src/Dropdown/View/Trigger.elm
+++ b/src/Dropdown/View/Trigger.elm
@@ -36,10 +36,11 @@ view : Config msg item -> State -> List item -> Maybe item -> Html (Msg item)
 view config state items selected =
     let
         styles =
-            [ ( "display", "flex" )
-            , ( "align-items", "center" )
-            , ( "cursor", "pointer" )
-            ]
+            List.append config.triggerStyles
+                [ ( "display", "flex" )
+                , ( "align-items", "center" )
+                , ( "cursor", "pointer" )
+                ]
 
         classes =
             config.triggerClass


### PR DESCRIPTION
Currently, the only manner to add styles to the trigger element is to
add a class to the element and then add styles through CSS. With this
change, you can add styles programmatically as one does with the other
elements.

PS. You will notice many formatting changes in `src/Dropdown.elm`. This was done by [elm-format](https://github.com/avh4/elm-format), a program I use to assure that the code I write is in line with Elm's community formatting guidelines. If you want, I can change the formatting to how it was before.